### PR TITLE
Add shell.nix file

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.cmake
+    pkgs.glew
+    pkgs.glfw
+    pkgs.stb
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 
 pkgs.mkShell {
   buildInputs = [
+    pkgs.cargo
     pkgs.glew
     pkgs.glfw
     pkgs.stb

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,6 @@
 
 pkgs.mkShell {
   buildInputs = [
-    pkgs.cmake
     pkgs.glew
     pkgs.glfw
     pkgs.stb


### PR DESCRIPTION
This adds a `shell.nix` file that can be used to install the needed dependencies to build imeye with Nix using  `nix-shell` command

Example:
```shell
♥ ❯ nix-shell
these 6 paths will be fetched (14.65 MiB download, 63.42 MiB unpacked):
  /nix/store/wjb1rq9xgxzq6n1b7pbrbsk5lrdn9qc7-cmake-3.31.3
  /nix/store/k2hmh270kdb988xizqp5wvlwgnhs1d8z-curl-8.11.1
  /nix/store/x52d5p5rpi8wm7nmqqg62wv3xq14zxi4-glew-2.2.0-bin
  /nix/store/41ps3cx1wzv7ni5j989rdrhs3zgaljan-glew-2.2.0-dev
  /nix/store/kllr5zx5gzyqyk76z6gyxbhcszzdm55a-rhash-1.4.4
  /nix/store/m18zm16psqifnp0m8l7x7siik9yiaia3-stb-unstable-2023-01-29
copying path '/nix/store/m18zm16psqifnp0m8l7x7siik9yiaia3-stb-unstable-2023-01-29' from 'https://cache.nixos.org'...
copying path '/nix/store/k2hmh270kdb988xizqp5wvlwgnhs1d8z-curl-8.11.1' from 'https://cache.nixos.org'...
copying path '/nix/store/kllr5zx5gzyqyk76z6gyxbhcszzdm55a-rhash-1.4.4' from 'https://cache.nixos.org'...
copying path '/nix/store/x52d5p5rpi8wm7nmqqg62wv3xq14zxi4-glew-2.2.0-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/41ps3cx1wzv7ni5j989rdrhs3zgaljan-glew-2.2.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/wjb1rq9xgxzq6n1b7pbrbsk5lrdn9qc7-cmake-3.31.3' from 'https://cache.nixos.org'...
          ▗▄▄▄       ▗▄▄▄▄    ▄▄▄▖             noah@nixos
          ▜███▙       ▜███▙  ▟███▛             ----------
           ▜███▙       ▜███▙▟███▛              OS: NixOS 25.05 (Warbler) x86_64
            ▜███▙       ▜██████▛               Kernel: Linux 6.13.1
     ▟█████████████████▙ ▜████▛     ▟▙         Uptime: 5 hours, 7 mins
    ▟███████████████████▙ ▜███▙    ▟██▙        Packages: 2688 (nix-system)
           ▄▄▄▄▖           ▜███▙  ▟███▛        Shell: zsh 5.9
          ▟███▛             ▜██▛ ▟███▛         Display (DELL U2412M): 1920x1200 @ 60 Hz in 24" [External]
         ▟███▛               ▜▛ ▟███▛          Display (VG248): 1920x1080 @ 165 Hz in 24" [External]
▟███████████▛                  ▟██████████▙    WM: Hyprland 0.47.0 (Wayland)
▜██████████▛                  ▟███████████▛    Theme: catppuccin-mocha-green [Qt], Colloid-Green-Dark-Catppuccin [GTK2/3/4]
      ▟███▛ ▟▙               ▟███▛             Icons: Papirus-Dark [Qt], Papirus-Dark [GTK2/3/4]
     ▟███▛ ▟██▙             ▟███▛              Cursor: catppuccin-mocha-dark
    ▟███▛  ▜███▙           ▝▀▀▀▀               Terminal: buildShellShim
    ▜██▛    ▜███▙ ▜██████████████████▛         CPU: AMD Ryzen 9 9950X (32) @ 5.75 GHz
     ▜▛     ▟████▙ ▜████████████████▛          GPU: AMD Radeon RX 6800 [Discrete]
           ▟██████▙       ▜███▙                Memory: 8.09 GiB / 62.45 GiB (13%)
          ▟███▛▜███▙       ▜███▙               Swap: Disabled
         ▟███▛  ▜███▙       ▜███▙              Disk (/): 155.98 GiB / 915.32 GiB (17%) - ext4
         ▝▀▀▀    ▀▀▀▀▘       ▀▀▀▘              Local IP (wlp10s0): 192.168.1.152/24
                                               Locale: en_US.UTF-8




imeye on  master [✘!?] via △ v3.31.3 via ❄️  impure (nix-shell)
♥ ❯ cmake .
CMake Warning (dev) at /nix/store/wjb1rq9xgxzq6n1b7pbrbsk5lrdn9qc7-cmake-3.31.3/share/cmake-3.31/Modules/FindOpenGL.cmake:415 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /nix/store/8a6na7jyfg3dr9z7pksijpp832632j98-libglvnd-1.7.0/lib/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /nix/store/8a6na7jyfg3dr9z7pksijpp832632j98-libglvnd-1.7.0/lib/libOpenGL.so
    OPENGL_glx_LIBRARY: /nix/store/8a6na7jyfg3dr9z7pksijpp832632j98-libglvnd-1.7.0/lib/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  CMakeLists.txt:13 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/noah/Documents/projects/cpp/imeye

imeye on  master [✘!?] via △ v3.31.3 via ❄️  impure (nix-shell)
♥ ❯ make
[100%] Built target imeye
```
note I am using cmake here but that's not included in this PR. Also this isn't a package either, but just sets up a temporary development shell instead explanation can be found [here](https://ghedam.at/15978/an-introduction-to-nix-shell)